### PR TITLE
Use full `Rails.env.development?` instead of call to `development?` private method

### DIFF
--- a/lib/shut_up_assets.rb
+++ b/lib/shut_up_assets.rb
@@ -18,7 +18,7 @@ class ShutUpAssets < Rails::Railtie # :nodoc-all:
       suppressed = ShutUpAssets.suppress_on?(request)
 
       # Put some space between requests in development logs.
-      logger.debug { EMPTY_LINE } if development? && !suppressed
+      logger.debug { EMPTY_LINE } if Rails.env.development? && !suppressed
 
       instrumenter = ActiveSupport::Notifications.instrumenter
       instrumenter.start 'request.action_dispatch', request: request


### PR DESCRIPTION
A recent change to Rails master means that this is no longer a "private helper method" named `development?` in railties-rails-rack-logger.  
This is a breaking change for shut_up_assets (i.e. The rails server fails to start)

Breaking change in Rails railties: https://github.com/rails/rails/commit/04021c4b78abc89045a7d3daf517a5d2dc63e5a7

This commit solves this issue by using the full call to `Rails.env.development?`